### PR TITLE
Remove useless use of injected-class-name

### DIFF
--- a/user/block.cpp
+++ b/user/block.cpp
@@ -40,7 +40,7 @@ BlockPtr BlocksCache::GetBlock(size_t no)
 	return block;
 }
 
-void BlocksCache::BlocksCache::Sync()
+void BlocksCache::Sync()
 {
 	std::fstream out(Config()->Device().c_str(),
 		std::ios::out | std::ios::in | std::ios::binary);


### PR DESCRIPTION
Change `BlocksCache::BlocksCache::Sync()` to just `BlocksCache::Sync()`. Actually, this is guaranteed to be equivalent (http://en.cppreference.com/w/cpp/language/unqualified_lookup#Injected_class_name) but it's somewhat cleaner. :-)